### PR TITLE
Correct .dune-project

### DIFF
--- a/dscheck.opam
+++ b/dscheck.opam
@@ -3,6 +3,7 @@ opam-version: "2.0"
 synopsis: "Traced Atomics"
 maintainer: ["Sadiq Jaffer"]
 authors: ["Sadiq Jaffer"]
+license: "ISC"
 homepage: "https://github.com/ocaml-multicore/dscheck"
 bug-reports: "https://github.com/ocaml-multicore/dscheck/issues"
 depends: [

--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,8 @@
 (generate_opam_files true)
 
 (name dscheck)
-(source (github sadiqj/dscheck))
+(source (github ocaml-multicore/dscheck))
+(license ISC)
 (authors "Sadiq Jaffer")
 (maintainers "Sadiq Jaffer")
 


### PR DESCRIPTION
Add license in dune-project (as added by opam maintainers in the [PR](https://github.com/ocaml/opam-repository/pull/22525) against opam) and regenerate dscheck.opam. 