### PR TITLE
Add make contended (introduced in OCaml.5.2.0)

### DIFF
--- a/src/tracedAtomic.ml
+++ b/src/tracedAtomic.ml
@@ -39,6 +39,8 @@ let make v =
     atomics_counter := !atomics_counter + 1;
     (Atomic.make v, i)
 
+let make_contended = make
+
 let get r =
   if !tracing then perform (Get r) else match r with v, _ -> Atomic.get v
 

--- a/src/tracedAtomic.mli
+++ b/src/tracedAtomic.mli
@@ -21,9 +21,16 @@ val make : 'a -> 'a t
 (** Create an atomic reference. *)
 
 val make_contended : 'a -> 'a t
-(** Create an atomic reference that is alone on a cache line. It occupies 4-16x the memory of one allocated with make v.
+(** Create an atomic reference that is alone on a cache line. It occupies 4-16x 
+the memory of one allocated with make v.
 
-The primary purpose is to prevent false-sharing and the resulting performance degradation. When a CPU performs an atomic operation, it temporarily takes ownership of an entire cache line that contains the atomic reference. If multiple atomic references share the same cache line, modifying these disjoint memory regions simultaneously becomes impossible, which can create a bottleneck. Hence, as a general guideline, if an atomic reference is experiencing contention, assigning it its own cache line may enhance performance.
+The primary purpose is to prevent false-sharing and the resulting performance 
+degradation. When a CPU performs an atomic operation, it temporarily takes 
+ownership of an entire cache line that contains the atomic reference. If 
+multiple atomic references share the same cache line, modifying these disjoint 
+memory regions simultaneously becomes impossible, which can create a bottleneck.
+Hence, as a general guideline, if an atomic reference is experiencing 
+contention, assigning it its own cache line may enhance performance.
 *)
 
 val get : 'a t -> 'a

--- a/src/tracedAtomic.mli
+++ b/src/tracedAtomic.mli
@@ -20,6 +20,12 @@ type !'a t
 val make : 'a -> 'a t
 (** Create an atomic reference. *)
 
+val make_contended : 'a -> 'a t
+(** Create an atomic reference that is alone on a cache line. It occupies 4-16x the memory of one allocated with make v.
+
+The primary purpose is to prevent false-sharing and the resulting performance degradation. When a CPU performs an atomic operation, it temporarily takes ownership of an entire cache line that contains the atomic reference. If multiple atomic references share the same cache line, modifying these disjoint memory regions simultaneously becomes impossible, which can create a bottleneck. Hence, as a general guideline, if an atomic reference is experiencing contention, assigning it its own cache line may enhance performance.
+*)
+
 val get : 'a t -> 'a
 (** Get the current value of the atomic reference. *)
 

--- a/tests/michael_scott_queue.ml
+++ b/tests/michael_scott_queue.ml
@@ -15,7 +15,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-(* Michael-Scott queue copied over from [lockfree](github.com/ocaml-multicore/lockfree) *)
+(* Michael-Scott queue copied over from [saturn](github.com/ocaml-multicore/saturn) *)
 module Atomic = Dscheck.TracedAtomic
 
 type 'a node = Nil | Next of 'a * 'a node Atomic.t
@@ -23,7 +23,7 @@ type 'a t = { head : 'a node Atomic.t; tail : 'a node Atomic.t }
 
 let create () =
   let head = Next (Obj.magic (), Atomic.make Nil) in
-  { head = Atomic.make head; tail = Atomic.make head }
+  { head = Atomic.make_contended head; tail = Atomic.make_contended head }
 
 let is_empty q =
   match Atomic.get q.head with

--- a/tests/test_trace.ml
+++ b/tests/test_trace.ml
@@ -2,7 +2,7 @@ module Atomic = Dscheck.TracedAtomic
 
 let counter incr () =
   let c1 = Atomic.make 0 in
-  let c2 = Atomic.make 0 in
+  let c2 = Atomic.make_contended 0 in
   Atomic.spawn (fun () -> incr c1);
   Atomic.spawn (fun () ->
       incr c1;


### PR DESCRIPTION
I simply added `Atomic.make_contended` to `dscheck` atomics but it is treated as  an `Atomic.make`. This avoids having to deal with previous compiler compatibility issues.